### PR TITLE
Fix many tiny style mistakes

### DIFF
--- a/src/conn.rs
+++ b/src/conn.rs
@@ -19,7 +19,8 @@ pub fn handle(mut stream: TcpStream) {
     let _ = match res {
         Ok((user, pw)) => {
             info!("Connection established. Handshake sent");
-            auth::find_user(&user, &pw)},
+            auth::find_user(&user, &pw)
+        },
         _ => Err(auth::AuthError::UserNotFound)
     };
 
@@ -32,7 +33,7 @@ pub fn handle(mut stream: TcpStream) {
         match command_res {
             Ok(cmd) =>
             match cmd {
-                //exit the session and shutdown the connection
+                // exit the session and shutdown the connection
                 Command::Quit => {
                     match net::send_ok_packet(&mut stream) {
                         Ok(_) => {
@@ -62,7 +63,7 @@ pub fn handle(mut stream: TcpStream) {
                     let ast = p.parse();
 
                     match ast {
-                    Ok(tree) => {
+                        Ok(tree) => {
                             println!("{:?}", tree);
                             query::execute_from_ast(tree, Some("testbase".into()));
                         },
@@ -76,7 +77,7 @@ pub fn handle(mut stream: TcpStream) {
                     continue
                 }
             },
-            Err(_) => continue//error handling
+            Err(_) => continue // TODO: error handling
         }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -15,12 +15,11 @@
 //! ...
 //!
 
-// TODO: Remove this line as soon as this module is actually used
-use std::io::{Write,Read};
+use std::io::{Write, Read};
 use byteorder::{ReadBytesExt, WriteBytesExt}; // for write_u16()
 // to encode and decode the structs to the given stream
 use bincode::rustc_serialize::{
-    decode_from, encode_into,EncodingError,DecodingError
+    decode_from, encode_into, EncodingError, DecodingError
 };
 use bincode::SizeLimit;
 use rustc_serialize::{Encodable, Encoder}; // to encode the Networkerrors
@@ -54,18 +53,30 @@ pub struct ClientErrMsg {
 impl From<NetworkErrors> for ClientErrMsg {
     fn from(error: NetworkErrors) -> ClientErrMsg {
         match error {
-            NetworkErrors::IoError(_) =>
-                ClientErrMsg { code: 0, msg: "IO error".into() },
-            NetworkErrors::ByteOrder(_) =>
-                ClientErrMsg { code: 1, msg: "Byteorder error".into() },
-            NetworkErrors::UnexpectedPkg(err) =>
-                ClientErrMsg { code: 2, msg: err.into() },
-            NetworkErrors::UnknownCmd(err) =>
-                ClientErrMsg { code: 3, msg: err.into() },
-            NetworkErrors::EncodeErr(_) =>
-                ClientErrMsg { code: 4, msg: "encoding error".into() },
-            NetworkErrors::DecodeErr(_) =>
-                ClientErrMsg { code: 5, msg: "decoding error".into() }
+            NetworkErrors::IoError(_) => ClientErrMsg {
+                code: 0,
+                msg: "IO error".into()
+            },
+            NetworkErrors::ByteOrder(_) => ClientErrMsg {
+                code: 1,
+                msg: "Byteorder error".into()
+            },
+            NetworkErrors::UnexpectedPkg(err) => ClientErrMsg {
+                code: 2,
+                msg: err.into()
+            },
+            NetworkErrors::UnknownCmd(err) => ClientErrMsg {
+                code: 3,
+                msg: err.into()
+            },
+            NetworkErrors::EncodeErr(_) => ClientErrMsg {
+                code: 4,
+                msg: "encoding error".into()
+            },
+            NetworkErrors::DecodeErr(_) => ClientErrMsg {
+                code: 5,
+                msg: "decoding error".into()
+            }
         }
     }
 }
@@ -118,7 +129,7 @@ pub struct Greeting {
 }
 
 impl Greeting {
-    pub fn make_greeting(version: u8, msg: String)-> Greeting {
+    pub fn make_greeting(version: u8, msg: String) -> Greeting {
         Greeting { protocol_version: version, message: msg }
     }
 }
@@ -158,7 +169,7 @@ impl Login {
 
 /// reads the data from the response to the handshake,
 /// username and password extracted and authenticated
-pub fn read_login<R: Read+Write>(stream: &mut R)
+pub fn read_login<R: Read + Write>(stream: &mut R)
     -> Result<Login, NetworkErrors>
 {
     // read the first byte
@@ -228,7 +239,7 @@ pub fn send_error_packet<W: Write>(mut stream: &mut W, err: ClientErrMsg)
 }
 
 /// Send ok packet
-pub fn send_ok_packet<W: Write> (mut stream: &mut W)
+pub fn send_ok_packet<W: Write>(mut stream: &mut W)
     -> Result<(), NetworkErrors>
 {
     try!(stream.write_u8(Cnv::OkPkg as u8));
@@ -269,14 +280,14 @@ pub fn test_send_ok_packet() {
 #[test]
 pub fn test_send_error_packet() {
     let mut vec = Vec::new();   // stream to write into
-    let vec2 = vec![Cnv::ErrorPkg as u8, //for error packet
+    let vec2 = vec![Cnv::ErrorPkg as u8, // for error packet
         0, 2, // for kind of error
         0, 0, 0, 0, 0, 0, 0, 17, // for the size of the message string
         117, 110, 101, 120, 112, 101, 99, 116, 101, 100, 32, 112, 97, 99, 107, 101, 116];
         // string itself
     let err = NetworkErrors::UnexpectedPkg("unexpected packet".into());
 
-    //test if the message is sent
+    // test if the message is sent
     let res = send_error_packet(&mut vec, err.into());
     assert_eq!(res.is_ok(), true);
     assert_eq!(vec, vec2);
@@ -284,7 +295,7 @@ pub fn test_send_error_packet() {
 
 #[test]
 pub fn test_read_commands(){
-    //test if the commands are correctly decoded
+    // test if the commands are correctly decoded
     use std::io::Cursor;        // stream to read from
     let mut vec = Vec::new();   // stream to write into
 
@@ -316,10 +327,10 @@ pub fn testlogin() {
     use std::io::Cursor;        // stream to read from
     let mut vec = Vec::new();   // stream to write into
 
-    //original struct
+    // original struct
     let login = Login { username: "elena".into(), password: "praktikum".into() };
     vec.push(1u8);
-    let login_encode = encode_into(&login,&mut vec,SizeLimit::Bounded(1024));
+    let login_encode = encode_into(&login, &mut vec, SizeLimit::Bounded(1024));
 
     let login_res = read_login(&mut Cursor::new(vec)).unwrap();
 

--- a/src/parse/ast.rs
+++ b/src/parse/ast.rs
@@ -134,9 +134,9 @@ pub enum Conditions {
 /// Information for the where-clause
 #[derive(Debug, Clone)]
 pub struct Condition {
-    pub col : String,
+    pub col: String,
     pub op: CompType,
-    pub rhs : CondType
+    pub rhs: CondType
 }
 
 /// Allowed operators for where-clause

--- a/src/parse/lex.rs
+++ b/src/parse/lex.rs
@@ -6,7 +6,7 @@ use std::iter::{Iterator};
 /// A lexer with its associated query, a char iterator, and
 /// positions (last, current, next)
 pub struct Lexer<'a> {
-    chs : Chars<'a>,
+    chs: Chars<'a>,
     last: Option<char>,
     last_pos: Option<usize>,
     curr: Option<char>,
@@ -26,14 +26,14 @@ impl<'a> Lexer<'a> {
             last_pos: None,
             next: None,
             span_start: None,
-            chs : query.chars()
+            chs: query.chars()
         };
         lex.dbump();
         lex
     }
 
     /// Bumper function advances to the next char
-    fn bump(&mut self){
+    fn bump(&mut self) {
 
         // advance all pointers to the next char
         self.last = self.curr;
@@ -55,7 +55,6 @@ impl<'a> Lexer<'a> {
             }
             _ => {}
         };
-
     }
 
     /// Double bump
@@ -124,7 +123,7 @@ impl<'a> Lexer<'a> {
 
     /// Skips all the whitespaces
     fn skip_whitespace(&mut self) {
-        while is_whitespace(self.curr.unwrap_or('x')){
+        while is_whitespace(self.curr.unwrap_or('x')) {
             self.bump();
         }
     }
@@ -230,7 +229,7 @@ impl<'a> Iterator for Lexer<'a> {
 
             // GEThan >=
             '>' if nexchar == '=' => {
-                self.dbump(); //because two chars!
+                self.dbump(); // because two chars!
                 Token::GEThan
             },
 
@@ -305,7 +304,10 @@ impl<'a> Iterator for Lexer<'a> {
         // Return an Option
         Some(TokenSpan {
             tok: token,
-            span: Span { lo: self.span_start.unwrap(), hi: self.curr_pos.unwrap()}
+            span: Span {
+                lo: self.span_start.unwrap(),
+                hi: self.curr_pos.unwrap()
+            }
         })
     }
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -8,6 +8,7 @@ pub mod ast;
 pub mod token;
 pub mod lex;
 pub mod parser;
+
 pub use self::parser::Parser;
 
 /// Represents a substring in the query string in byte indices.

--- a/src/parse/token.rs
+++ b/src/parse/token.rs
@@ -20,7 +20,7 @@ pub enum Token {
     Word(String),
     Num(String),
 
-    //detects literals
+    // detects literals
     Literal(Lit),
 
     Semi,
@@ -29,12 +29,12 @@ pub enum Token {
     // Bang,
     // QMark,
 
-    //delimiter (,),',"
+    // delimiter (,),',"
     ParenOp,
     ParenCl,
     ADel,
 
-    //mathematic ops
+    // mathematic ops
     Equ,
     GThan,
     SThan,
@@ -46,7 +46,7 @@ pub enum Token {
     Div,
     Mod,
 
-    //sensitive Wildcard/Mult, eval in parser
+    // sensitive Wildcard/Mult, eval in parser
     Star,
 
     Whitespace,

--- a/src/storage/flatfile.rs
+++ b/src/storage/flatfile.rs
@@ -27,7 +27,7 @@ impl<'a> Engine for FlatFile<'a> {
         Ok(())
     }
 
-    fn table(&self) -> &Table{
+    fn table(&self) -> &Table {
         &self.table
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -27,8 +27,8 @@ use bincode::rustc_serialize::{EncodingError,
     DecodingError, encode_into, decode_from};
 
 /// constants
- const MAGIC_NUMBER: u64 = 0x6561742073686974; // secret
- const VERSION_NO: u8 = 1;
+const MAGIC_NUMBER: u64 = 0x6561742073686974; // secret
+const VERSION_NO: u8 = 1;
 
 
 /// A database table
@@ -44,7 +44,7 @@ pub enum DatabaseError {
     BinDe(DecodingError),
     Byteorder(::byteorder::Error),
     WrongMagicNmbr,
-    Engine, //cur not used
+    Engine, // cur not used
     LoadDataBase,
     RemoveColumn,
     AddColumn,
@@ -68,7 +68,7 @@ impl From<DecodingError> for DatabaseError {
     }
 }
 
-impl From< ::byteorder::Error> for DatabaseError {
+impl From<::byteorder::Error> for DatabaseError {
     fn from(err: ::byteorder::Error) -> DatabaseError {
         DatabaseError::Byteorder(err)
     }
@@ -79,7 +79,7 @@ impl From< ::byteorder::Error> for DatabaseError {
 //---------------------------------------------------------------
 /// A Enum for Datatypes (will be removed later)
 #[repr(u8)]
-#[derive(Clone,Copy,Debug,RustcDecodable, RustcEncodable)]
+#[derive(Clone, Copy, Debug, RustcDecodable, RustcEncodable)]
 pub enum DataType { Integer = 1, Float = 2, }
 
 impl DataType {
@@ -102,7 +102,7 @@ impl Database {
     pub fn create(name: &str) -> Result<Database, DatabaseError> {
         let d = Database{ name: name.to_string() };
         try!(d.save());
-        info!("created new database {:?}",d);
+        info!("created new database {:?}", d);
         Ok(d)
     }
 
@@ -157,7 +157,7 @@ impl Database {
 //---------------------------------------------------------------
 
 #[derive(Debug, RustcDecodable, RustcEncodable)]
-pub struct  TableMetaData {
+pub struct TableMetaData {
     version_nmbr: u8,
     engine_id: u8,
     columns: Vec<Column>,
@@ -212,7 +212,7 @@ impl<'a> Table<'a> {
         info!("reading file: {:?}", file);
         let ma_nmbr = try!(file.read_uint::<BigEndian>(mem::size_of_val(&MAGIC_NUMBER)));
 
-        info!("checking magic number: {:?}",ma_nmbr);
+        info!("checking magic number: {:?}", ma_nmbr);
         if ma_nmbr != MAGIC_NUMBER {
             println!("Magic Number not correct");
             return Err(DatabaseError::WrongMagicNmbr)
@@ -229,15 +229,15 @@ impl<'a> Table<'a> {
     /// Returns DatabaseError on fail else Nothing
     pub fn save(&self) -> Result<(), DatabaseError> {
         // call for open file
-        info!("opening file to write",);
+        info!("opening file to write");
         let mut file = try!(OpenOptions::new()
             .write(true)
             .create(true)
             .open(self.get_table_metadata_path()));
         info!("writing magic number in file: {:?}", file);
         try!(file.write_u64::<BigEndian>(MAGIC_NUMBER));//MAGIC_NUMBER
-        info!("writing meta data in file: {:?}",file);
-        try!(encode_into(&self.meta_data, &mut file,SizeLimit::Infinite));
+        info!("writing meta data in file: {:?}", file);
+        try!(encode_into(&self.meta_data, &mut file, SizeLimit::Infinite));
 
         // debug message all okay
         info!("I Wrote my File");
@@ -253,7 +253,7 @@ impl<'a> Table<'a> {
         info!("remove meta file: {:?}", self.get_table_metadata_path());
         try!(fs::remove_file(self.get_table_metadata_path()));
 
-        info!("remove data file: {:?}",self.get_table_data_path());
+        info!("remove data file: {:?}", self.get_table_data_path());
         try!(fs::remove_file(self.get_table_data_path()));
 
         Ok(())
@@ -285,7 +285,7 @@ impl<'a> Table<'a> {
     pub fn remove_column(&mut self, name: &str) -> Result<(), DatabaseError> {
         let index = match self.meta_data.columns.iter().position(|x| x.name == name) {
             Some(x) => {
-                info!("Column {:?} was removed" , self.name);
+                info!("Column {:?} was removed", self.name);
                 x
             },
             None => {


### PR DESCRIPTION
This PR mostly adds and removes whitespaces. I fixed tiny style mistakes without changing too much code. I went through:
- the whole storage module
- the whole parse module
- `net.rs` and `conn.rs` 
-  `main.rs`

That means I ignored:
- `query.rs`: It was just temporary anyway, it will change a whole lot soon.
- `bin/client.rs`: This code will probably change soon, too
- `bin/*.rs`: All other files in `bin` are just for testing of subgroups, so I didn't bother...

I furthermore thought about the structure of some files and created two issues: One for the [network group](https://github.com/OsnaCS/uosql-server/issues/52) and one for the [parsing group](https://github.com/OsnaCS/uosql-server/issues/51). In those issues I commented on things other than style mistakes. 

What I'll do tomorrow:
- Restructure the whole project (means: moving files around, rarely changing them)
- Add some basic structure to the `storage` module to lay the foundation for future work
- Create an issue for the `storage` group explaining the work that needs to be done
