### PR TITLE
Change inefficient code

### DIFF
--- a/server/examples/parser.rs
+++ b/server/examples/parser.rs
@@ -8,7 +8,7 @@ use server::parse;
 
 fn main() {
 
-    let mut p = parse::Parser::create("create table Lisa (Name varchar(2044243))");
+    let mut p = parse::Parser::create("delete from Lisa");
 
     println!("{:?}",p.parse());
 

--- a/server/examples/parser.rs
+++ b/server/examples/parser.rs
@@ -8,7 +8,7 @@ use server::parse;
 
 fn main() {
 
-    let mut p = parse::Parser::create("create table test");
+    let mut p = parse::Parser::create("create table Lisa (Name varchar(2044243))");
 
     println!("{:?}",p.parse());
 

--- a/server/src/parse/ast.rs
+++ b/server/src/parse/ast.rs
@@ -1,4 +1,5 @@
 /// Top level type. Is returned by `parse`.
+use super::token;
 #[derive(Debug, Clone)]
 pub enum Query {
     Dummy, // For Compiling
@@ -104,7 +105,7 @@ pub struct SelectStmt {
 pub struct InsertStmt {
     pub tid: String,
     pub col: Vec<String>,
-    pub val: Vec<SqlType>
+    pub val: Vec<token::Lit>
 }
 
 /// Information for data deletion

--- a/server/src/parse/lex.rs
+++ b/server/src/parse/lex.rs
@@ -116,8 +116,9 @@ impl<'a> Lexer<'a> {
                     s.push(c);
                 }
             }
-            self.dbump();
+            self.bump();
         }
+        self.bump();
         s
     }
 

--- a/server/src/parse/lex.rs
+++ b/server/src/parse/lex.rs
@@ -116,7 +116,7 @@ impl<'a> Lexer<'a> {
                     s.push(c);
                 }
             }
-            self.bump();
+            self.dbump();
         }
         s
     }
@@ -127,6 +127,28 @@ impl<'a> Lexer<'a> {
             self.bump();
         }
     }
+
+    /// Returns next token that is not a whitespace
+    pub fn next_real(&mut self) -> Option<TokenSpan> {
+        let tokspanop = self.next();
+        let  wspace = match tokspanop {
+            Some(ref tokspan) => {
+                match tokspan.tok {
+                    Token::Whitespace => true,
+                    _ => false
+                }
+
+            }
+            _ => false,
+        };
+
+        if wspace {
+            self.next()
+        } else {
+            tokspanop
+        }
+    }
+
 }
 
 /// Checks for whitespace/line break/tab
@@ -162,14 +184,21 @@ impl<'a> Iterator for Lexer<'a> {
             // Words
             'a' ... 'z' | 'A' ... 'Z' => {
                 let w = self.scan_words();
-                Token::Word(w.to_lowercase())
+                Token::Word(w)
             },
 
-            // Nums
+            // Lit Num
             '0' ... '9' => {
                 let n = self.scan_nums();
-                Token::Num(n)
-
+                if let Ok(i) = n.parse::<i64>() {
+                    Token::Literal(Lit::Int(i))
+                } else {
+                    if let Ok(f) = n.parse::<f64>() {
+                        Token::Literal(Lit::Float(f))
+                    } else {
+                        Token::Unknown
+                    }
+                }
             },
 
             // Semicolon
@@ -217,7 +246,6 @@ impl<'a> Iterator for Lexer<'a> {
             // Literals
             '\'' | '"' => {
                 let l = self.scan_lit();
-                self.bump();
                 Token::Literal(Lit::Str(l))
             },
 

--- a/server/src/parse/token.rs
+++ b/server/src/parse/token.rs
@@ -10,7 +10,8 @@ pub struct TokenSpan {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Lit {
 	Str(String),
-	Int(String)
+	Int(i64),
+    Float(f64)
 }
 
 /// A token: Everything the lexer can produce
@@ -18,7 +19,6 @@ pub enum Lit {
 pub enum Token {
 
     Word(String),
-    Num(String),
 
     // detects literals
     Literal(Lit),


### PR DESCRIPTION
Lexer converts numbers to i64/f64, implemented next_real function to avoid whitespaces
and other minor changes.
