### PR TITLE
Add unique error messages for errors to display

### DIFF
--- a/server/src/conn.rs
+++ b/server/src/conn.rs
@@ -8,7 +8,7 @@ use super::query;
 use net::types::*;
 use storage::{Rows};
 use storage::types::{SqlType, Column};
-use net::Error;
+use std::error::Error;
 
 pub fn handle(mut stream: TcpStream) {
     // Logging about the new connection
@@ -28,7 +28,7 @@ pub fn handle(mut stream: TcpStream) {
                         PkgType::AccGranted)
                     {
                         Ok(_) => {},
-                        Err(_) => return
+                        Err(e) => { error!("{}", e.description()); return }
                     }
                 },
                 Err(_) => {
@@ -107,7 +107,9 @@ pub fn handle(mut stream: TcpStream) {
 
                         Err(error) => {
                             error!("{:?}", error);
-                            match net::send_error_package(&mut stream, Error::UnEoq(error).into()) {
+                            match net::send_error_package(&mut stream,
+                                net::Error::UnEoq(error).into())
+                            {
                                 Ok(_) => {},
                                 Err(_) => warn!("Failed to send error.")
                             }

--- a/server/src/net/mod.rs
+++ b/server/src/net/mod.rs
@@ -24,6 +24,8 @@ use bincode::SizeLimit;
 use self::types::*;
 use storage::Rows;
 use parse::parser::ParseError;
+use std;
+use std::fmt;
 
 const PROTOCOL_VERSION: u8 = 1;
 
@@ -31,11 +33,32 @@ const PROTOCOL_VERSION: u8 = 1;
 #[derive(Debug)]
 pub enum Error {
     Io(io::Error),
-    UnexpectedPkg(String),
-    UnknownCmd(String),
+    UnexpectedPkg,
+    UnknownCmd,
     Encode(EncodingError),
     Decode(DecodingError),
     UnEoq(ParseError),
+}
+
+/// Implement display for description of Error
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        std::error::Error::description(self).fmt(f)
+    }
+}
+
+/// Implement description for this Error enum
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        match self {
+            &Error::Io(_) => "IO error occured",
+            &Error::UnexpectedPkg => "received unexpected package",
+            &Error::UnknownCmd => "cannot interpret command: unknown",
+            &Error::Encode(_) => "could not encode/ send package",
+            &Error::Decode(_) => "could not decode/ receive package",
+            &Error::UnEoq(_) => "parsing error"
+        }
+    }
 }
 
 /// Implement the conversion from io::Error to NetworkError
@@ -94,7 +117,7 @@ pub fn read_login<R: Read + Write>(stream: &mut R)
     let status: PkgType = try!(decode_from(stream, SizeLimit::Bounded(1024)));
 
     if status != PkgType::Login {
-        return Err(Error::UnexpectedPkg("package not expected".into()));
+        return Err(Error::UnexpectedPkg);
     }
 
     // read the login data
@@ -135,7 +158,7 @@ pub fn read_commands<R: Read + Write>(stream: &mut R)
     let status: PkgType = try!(decode_from(stream, SizeLimit::Bounded(1024)));
     if status != PkgType::Command {
         //send error_packet
-        return Err(Error::UnknownCmd("command not known".into()))
+        return Err(Error::UnknownCmd)
     }
 
     // second  4 bytes is the kind of command
@@ -170,12 +193,13 @@ pub fn test_send_ok_packet() {
 #[test]
 pub fn test_send_error_packet() {
     let mut vec = Vec::new();   // stream to write into
+    // could not encode/ send package
     let vec2 = vec![0, 0, 0, 3, // for error packet
         0, 2, // for kind of error
-        0, 0, 0, 0, 0, 0, 0, 17, // for the size of the message string
-        117, 110, 101, 120, 112, 101, 99, 116, 101, 100,
-        32, 112, 97, 99, 107, 101, 116]; // string itself
-    let err = Error::UnexpectedPkg("unexpected packet".into());
+        0, 0, 0, 0, 0, 0, 0, 27, // for the size of the message string
+        114, 101, 99, 101, 105, 118, 101, 100, 32, 117, 110, 101, 120, 112, 101,
+        99, 116, 101, 100, 32, 112, 97, 99, 107, 97, 103, 101]; // string itself
+    let err = Error::UnexpectedPkg;
 
     // test if the message is sent
     let res = send_error_package(&mut vec, err.into());

--- a/server/src/net/types.rs
+++ b/server/src/net/types.rs
@@ -3,6 +3,7 @@
 /// about 3 months ;)
 
 use storage::types::Column;
+use std::error::Error;
 
 /// Code numeric value sent as first byte
 #[derive(PartialEq, RustcEncodable, RustcDecodable)]
@@ -31,27 +32,27 @@ impl From<super::Error> for ClientErrMsg {
         match error {
             super::Error::Io(_) => ClientErrMsg {
                 code: 0,
-                msg: "IO error".into()
+                msg: error.description().into()
             },
-            super::Error::UnexpectedPkg(err) => ClientErrMsg {
+            super::Error::UnexpectedPkg => ClientErrMsg {
                 code: 2,
-                msg: err.into()
+                msg: error.description().into()
             },
-            super::Error::UnknownCmd(err) => ClientErrMsg {
+            super::Error::UnknownCmd => ClientErrMsg {
                 code: 3,
-                msg: err.into()
+                msg: error.description().into()
             },
             super::Error::Encode(_) => ClientErrMsg {
                 code: 4,
-                msg: "encoding error".into()
+                msg: error.description().into()
             },
             super::Error::Decode(_) => ClientErrMsg {
                 code: 5,
-                msg: "decoding error".into()
+                msg: error.description().into()
             },
-            super::Error::UnEoq(e) => ClientErrMsg {
+            super::Error::UnEoq(_) => ClientErrMsg {
                 code: 6,
-                msg: "Parse error".into()
+                msg: error.description().into()
             }
         }
     }

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -12,12 +12,12 @@ extern crate server;
 use std::io::{self, stdout, Write};
 use std::str::FromStr;
 use uosql::logger;
-use uosql::Error;
 use uosql::Connection;
 use server::storage::Rows;
 use docopt::Docopt;
 use std::net::Ipv4Addr;
 use std::cmp::{max, min};
+use std::error::Error;
 
 /// For console input, manages flags and arguments
 const USAGE: &'static str = "
@@ -97,32 +97,32 @@ fn main() {
         Ok(conn) => conn,
         Err(e) => {
             match e {
-                Error::AddrParse(_) => {
-                    error!("Could not connect to specified server.");
+                uosql::Error::AddrParse(_) => {
+                    error!("{}", e.description());
                     return
                 },
-                Error::Io(_) => {
-                    error!("Connection failure. Try again later.");
+                uosql::Error::Io(_) => {
+                    error!("{}", e.description());
                     return
                 },
-                Error::Decode(_) => {
-                    error!("Could not read data from server.");
+                uosql::Error::Decode(_) => {
+                    error!("{}", e.description());
                     return
                 },
-                Error::Encode(_) => {
-                    error!("Could not send data to server.");
+                uosql::Error::Encode(_) => {
+                    error!("{}", e.description());
                     return
                 },
-                Error::UnexpectedPkg(e) => {
-                    error!("{}", e.to_string());
+                uosql::Error::UnexpectedPkg => {
+                    error!("{}", e.description());
                     return
                 },
-                Error::Auth(e) => {
-                    info!("{}", e.to_string());
+                uosql::Error::Auth => {
+                    info!("{}", e.description());
                     return
                 },
-                Error::Server(e) => {
-                    error!("{}", e.msg);
+                uosql::Error::Server(_) => {
+                    error!("{}", e.description());
                     return
                 }
             }
@@ -162,8 +162,8 @@ fn process_input(input: &str, conn: &mut Connection) -> bool {
         ":quit" => {
             match conn.quit() {
                 Ok(_) => return false,
-                Err(_) => {
-                    error!("Sending quit-message failed");
+                Err(e) => {
+                    error!("Quit: {}", e.description());
                     return true
                 }
             }
@@ -174,8 +174,8 @@ fn process_input(input: &str, conn: &mut Connection) -> bool {
                     println!("Server still reachable.");
                     return true
                 },
-                Err(_) => {
-                    error!("Sending ping-message failed");
+                Err(e) => {
+                    error!("Ping: {}", e.description());
                     return true
                 }
             }
@@ -187,8 +187,8 @@ fn process_input(input: &str, conn: &mut Connection) -> bool {
                     println!("Bye bye.");
                     return false
                 },
-                Err(_) => {
-                    error!("Sending quit-message failed");
+                Err(e) => {
+                    error!("Exit: {}", e.description());
                     return false
                 }
             }
@@ -206,24 +206,24 @@ fn process_input(input: &str, conn: &mut Connection) -> bool {
                 },
                 Err(e) => {
                     match e {
-                        Error::Io(_) => {
-                            error!("Connection failure. Try again later.");
+                        uosql::Error::Io(_) => {
+                            error!("{}", e.description());
                             return true
                         },
-                        Error::Decode(_) => {
-                            error!("Could not read data from server.");
+                        uosql::Error::Decode(_) => {
+                            error!("{}", e.description());
                             return true
                         }
-                        Error::Encode(_) => {
-                            error!("Could not send data to server.");
+                        uosql::Error::Encode(_) => {
+                            error!("{}", e.description());
                             return true
                         }
-                        Error::UnexpectedPkg(e) => {
-                            error!("{}", e.to_string());
+                        uosql::Error::UnexpectedPkg => {
+                            error!("{}", e.description());
                             return true
                         },
-                        Error::Server(e) => {
-                            error!("{}", e.msg);
+                        uosql::Error::Server(_) => {
+                            error!("{}", e.description());
                             return true
                         }
                         _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,41 @@ use bincode::rustc_serialize::{EncodingError, DecodingError,
     decode_from, encode_into};
 use types::*;
 use server::storage::Rows;
+use std::fmt;
 
 // const PROTOCOL_VERSION : u8 = 1;
 
+#[derive(Debug)]
 pub enum Error {
     AddrParse(AddrParseError),
     Io(io::Error),
-    UnexpectedPkg(String),
+    UnexpectedPkg,
     Encode(EncodingError),
     Decode(DecodingError),
-    Auth(String),
+    Auth,
     Server(ClientErrMsg),
+}
+
+/// Implement display for description of Error
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        std::error::Error::description(self).fmt(f)
+    }
+}
+
+/// Implement description for this Error enum
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        match self {
+            &Error::AddrParse(_) => "wrong IPv4 address format",
+            &Error::Io(_) => "IO error occured",
+            &Error::UnexpectedPkg => "received unexpected package",
+            &Error::Encode(_) => "could not encode/ send package",
+            &Error::Decode(_) => "could not decode/ receive package",
+            &Error::Auth => "could not authenticate user",
+            &Error::Server(ref e) => { &e.msg }
+        }
+    }
 }
 
 /// Implement the conversion from io::Error to Connection-Error
@@ -114,9 +138,8 @@ impl Connection {
                 Ok(Connection { ip: addr, port: port, tcp: tmp_tcp,
                     greeting: greet, user_data: log} ),
             PkgType::AccDenied =>
-                Err(Error::Auth("Authentication failure.".into())),
-            _ => Err(Error::UnexpectedPkg("Unexpected package
-                    received. Server is INSANE.".into()))
+                Err(Error::Auth),
+            _ => Err(Error::UnexpectedPkg)
         }
     }
 
@@ -209,7 +232,7 @@ fn receive(s: &mut TcpStream, cmd: PkgType) -> Result<(), Error> {
             },
             _ => {}
         }
-        return Err(Error::UnexpectedPkg("Received unexpected package".into()))
+        return Err(Error::UnexpectedPkg)
     }
     Ok(())
 }


### PR DESCRIPTION
Every error now has a short message to signal what went wrong. This can be accessed via Error.description()
